### PR TITLE
Add English language option with translations

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,18 +4,156 @@
    - Widgets werden on-demand geladen (Shadow DOM), Demodaten via data/demo.js
    ============================================================================ */
 
-const routes = {
-  dashboard: { title: 'Dashboard', file: 'widgets/dashboard.html' },
-  map:       { title: 'Karte',     file: 'widgets/map.html' },
-  calendar:  { title: 'Kalender',  file: 'widgets/calendar.html' },
-  rain:      { title: 'Niederschlag', file: 'widgets/rain.html' }
-};
-
 const state = {
   user: { firstName: '', lastName: '' },
   ui:   { dark: false, reduceMotion: false, highContrast: false },
-  route: 'dashboard'
+  route: 'dashboard',
+  lang: 'de'
 };
+
+const routes = {
+  dashboard: { titleKey: 'titleDashboard', file: 'widgets/dashboard.html' },
+  map:       { titleKey: 'titleMap',       file: 'widgets/map.html' },
+  calendar:  { titleKey: 'titleCalendar',  file: 'widgets/calendar.html' },
+  rain:      { titleKey: 'titleRain',      file: 'widgets/rain.html' }
+};
+
+const translations = {
+  de: {
+    splashLoading: 'App wird geladen…',
+    loading: 'Ladevorgang',
+    progress: 'Fortschritt',
+    titleDashboard: 'Dashboard',
+    titleMap: 'Karte',
+    titleCalendar: 'Kalender',
+    titleRain: 'Niederschlag',
+    navHome: 'Home',
+    navMap: 'Karte',
+    navCalendar: 'Kalender',
+    navRain: 'Regen',
+    settings: 'Einstellungen',
+    close: 'Schließen',
+    appearance: 'Darstellung',
+    darkMode: 'Dark Mode aktivieren',
+    reduceMotion: 'Animationen reduzieren',
+    highContrast: 'Hohen Kontrast (AAA) aktivieren',
+    personalization: 'Personalisierung',
+    firstName: 'Vorname',
+    lastName: 'Nachname',
+    nameHint: 'Dein Name erscheint an mehreren Stellen (z. B. „Guten Morgen, Michael“).',
+    language: 'Sprache',
+    dataSource: 'Datenquelle',
+    dataHint: 'Aktuell werden Demodaten verwendet. Später wird hier ThingsBoard verbunden.',
+    save: 'Speichern',
+    openSettings: 'Einstellungen öffnen',
+    navigation: 'Navigation',
+    header: 'Kopfzeile',
+    settingsSaved: 'Danke, {name}! Einstellungen gespeichert.',
+    friend: 'Freund',
+    loadError: 'Fehler beim Laden',
+    hello: 'Hallo!',
+    helloName: 'Hallo {name}!',
+    demoSub: 'Demodaten – ThingsBoard Anbindung folgt.',
+    temperature: 'Temperatur',
+    rain: 'Niederschlag',
+    wind: 'Wind',
+    humidity: 'Luftfeuchte',
+    current: 'Aktuell',
+    minToday: 'Min heute',
+    maxToday: 'Max heute',
+    today: 'Heute',
+    lastHour: 'Letzte Stunde',
+    sum24h: '24 h Summe',
+    average: 'Ø',
+    gust: 'Böe',
+    direction: 'Richtung',
+    highShort: 'H',
+    lowShort: 'T',
+    rainOverview: 'Niederschlags-Übersicht',
+    range24h: '24 h',
+    range48h: '48 h',
+    range7d: '7 Tage',
+    range30d: '30 Tage',
+    inPeriod: 'im Zeitraum',
+    evtMaintNussdorf: 'Wartung Station Nussdorf',
+    evtSensorWaidach: 'Sensorwechsel Waidach',
+    evtStorm: 'Sturm – erhöhte Böen',
+    evtSoftwareUpdate: 'Softwareupdate'
+  },
+  en: {
+    splashLoading: 'Loading app…',
+    loading: 'Loading',
+    progress: 'Progress',
+    titleDashboard: 'Dashboard',
+    titleMap: 'Map',
+    titleCalendar: 'Calendar',
+    titleRain: 'Rain',
+    navHome: 'Home',
+    navMap: 'Map',
+    navCalendar: 'Calendar',
+    navRain: 'Rain',
+    settings: 'Settings',
+    close: 'Close',
+    appearance: 'Appearance',
+    darkMode: 'Enable dark mode',
+    reduceMotion: 'Reduce motion',
+    highContrast: 'Enable high contrast (AAA)',
+    personalization: 'Personalization',
+    firstName: 'First name',
+    lastName: 'Last name',
+    nameHint: 'Your name appears in several places (e.g., “Good morning, Michael”).',
+    language: 'Language',
+    dataSource: 'Data source',
+    dataHint: 'Currently demo data is used. Later, ThingsBoard will be connected here.',
+    save: 'Save',
+    openSettings: 'Open settings',
+    navigation: 'Navigation',
+    header: 'Header',
+    settingsSaved: 'Thanks, {name}! Settings saved.',
+    friend: 'friend',
+    loadError: 'Error loading',
+    hello: 'Hello!',
+    helloName: 'Hello {name}!',
+    demoSub: 'Demo data – ThingsBoard integration coming soon.',
+    temperature: 'Temperature',
+    rain: 'Rain',
+    wind: 'Wind',
+    humidity: 'Humidity',
+    current: 'Current',
+    minToday: 'Min today',
+    maxToday: 'Max today',
+    today: 'Today',
+    lastHour: 'Last hour',
+    sum24h: '24 h total',
+    average: 'Avg',
+    gust: 'Gust',
+    direction: 'Direction',
+    highShort: 'H',
+    lowShort: 'L',
+    rainOverview: 'Rainfall overview',
+    range24h: '24 h',
+    range48h: '48 h',
+    range7d: '7 days',
+    range30d: '30 days',
+    inPeriod: 'during period',
+    evtMaintNussdorf: 'Maintenance Nussdorf station',
+    evtSensorWaidach: 'Sensor replacement Waidach',
+    evtStorm: 'Storm – increased gusts',
+    evtSoftwareUpdate: 'Software update'
+  }
+};
+
+function t(key){
+  return (translations[state.lang] || {})[key] || key;
+}
+
+function translate(root=document){
+  $$('[data-i18n]', root).forEach(el=>{ el.textContent = t(el.dataset.i18n); });
+  $$('[data-i18n-placeholder]', root).forEach(el=>{ el.setAttribute('placeholder', t(el.dataset.i18nPlaceholder)); });
+  $$('[data-i18n-aria-label]', root).forEach(el=>{ el.setAttribute('aria-label', t(el.dataset.i18nAriaLabel)); });
+}
+
+window.t = t;
 
 /* ---------------- Splash ---------------- */
 const splash = document.getElementById('splash');
@@ -40,6 +178,7 @@ $('#btnSettings').addEventListener('click', () => {
   $('#darkToggle').checked = state.ui.dark;
   $('#reduceMotion').checked = state.ui.reduceMotion;
   $('#highContrast').checked = state.ui.highContrast;
+  $('#language').value     = state.lang;
   dlg.showModal();
 });
 
@@ -50,13 +189,20 @@ $('#saveSettings').addEventListener('click', (e) => {
   state.ui.dark        = $('#darkToggle').checked;
   state.ui.reduceMotion= $('#reduceMotion').checked;
   state.ui.highContrast= $('#highContrast').checked;
+  const prevLang       = state.lang;
+  state.lang           = $('#language').value;
 
   save('cws_user', state.user);
   save('cws_ui', state.ui);
+  save('cws_lang', state.lang);
   applyUiPrefs();
+  translate();
+  document.documentElement.lang = state.lang;
+  title(t(routes[state.route].titleKey));
   dlg.close();
+  if (state.lang !== prevLang) mount(state.route);
   // freundlicher Toast
-  toast(`Danke, ${state.user.firstName || 'Freund'}! Einstellungen gespeichert.`);
+  toast(t('settingsSaved').replace('{name}', state.user.firstName || t('friend')));
 });
 
 /* ---------------- UI Prefs ---------------- */
@@ -84,7 +230,7 @@ async function mount(route){
     b.setAttribute('aria-selected', String(on));
   });
 
-  title(r.title);
+  title(t(r.titleKey));
 
   try {
     const html = await loadWidgetHtml(r.file);
@@ -94,6 +240,7 @@ async function mount(route){
     host.innerHTML = html; // enthält eigene CSS/JS Includes
     $('#app').innerHTML = '';
     $('#app').appendChild(host);
+    translate(host);
     setProgress(70);
 
     // Personalisierung in Widgets verfügbar machen
@@ -104,7 +251,7 @@ async function mount(route){
     setProgress(100);
   } catch (e) {
     console.error(e);
-    $('#app').innerHTML = `<div class="widget-card" style="padding:16px">Fehler beim Laden: ${e.message}</div>`;
+    $('#app').innerHTML = `<div class="widget-card" style="padding:16px">${t('loadError')}: ${e.message}</div>`;
   } finally {
     hideSplash();
   }
@@ -145,7 +292,10 @@ if ('serviceWorker' in navigator) {
   // Load prefs
   state.user = load('cws_user', state.user);
   state.ui   = load('cws_ui', state.ui);
+  state.lang = load('cws_lang', state.lang);
+  document.documentElement.lang = state.lang;
   applyUiPrefs();
+  translate();
 
   firstRun();
   await mount('dashboard'); // Startseite

--- a/index.html
+++ b/index.html
@@ -24,19 +24,19 @@
 
 <body>
   <!-- Splash (leicht animiert, barrierearm) -->
-  <div id="splash" aria-live="polite" aria-label="Ladevorgang" class="splash visible">
+  <div id="splash" aria-live="polite" class="splash visible" data-i18n-aria-label="loading">
     <img src="assets/icon-192.png" alt="CWS Logo" width="128" height="128" />
-    <p id="splashText">App wird geladen…</p>
-    <div class="progress" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" aria-label="Fortschritt">
+    <p id="splashText" data-i18n="splashLoading">App wird geladen…</p>
+    <div class="progress" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" data-i18n-aria-label="progress">
       <div class="bar" id="progressBar" style="width:0%"></div>
     </div>
   </div>
 
   <!-- App-Header -->
-  <header id="appHeader" class="app-header" aria-label="Kopfzeile">
+  <header id="appHeader" class="app-header" data-i18n-aria-label="header">
     <h1 class="brand">CWS</h1>
-    <div class="title" id="pageTitle">Dashboard</div>
-    <button id="btnSettings" class="icon-btn" aria-label="Einstellungen öffnen">
+    <div class="title" id="pageTitle" data-i18n="titleDashboard">Dashboard</div>
+    <button id="btnSettings" class="icon-btn" data-i18n-aria-label="openSettings">
       <i class="fa-solid fa-gear"></i>
     </button>
   </header>
@@ -45,65 +45,72 @@
   <main id="app" class="app" role="main" aria-live="polite"></main>
 
   <!-- Bottom Nav -->
-  <nav id="nav" class="nav" role="tablist" aria-label="Navigation">
-    <button class="nav-btn active" data-route="dashboard" role="tab" aria-selected="true" aria-label="Startseite">
-      <i class="fa-solid fa-house"></i><span>Home</span>
+  <nav id="nav" class="nav" role="tablist" data-i18n-aria-label="navigation">
+    <button class="nav-btn active" data-route="dashboard" role="tab" aria-selected="true" data-i18n-aria-label="navHome">
+      <i class="fa-solid fa-house"></i><span data-i18n="navHome">Home</span>
     </button>
-    <button class="nav-btn" data-route="map" role="tab" aria-selected="false" aria-label="Karte">
-      <i class="fa-solid fa-map"></i><span>Karte</span>
+    <button class="nav-btn" data-route="map" role="tab" aria-selected="false" data-i18n-aria-label="navMap">
+      <i class="fa-solid fa-map"></i><span data-i18n="navMap">Karte</span>
     </button>
-    <button class="nav-btn" data-route="calendar" role="tab" aria-selected="false" aria-label="Kalender">
-      <i class="fa-solid fa-calendar"></i><span>Kalender</span>
+    <button class="nav-btn" data-route="calendar" role="tab" aria-selected="false" data-i18n-aria-label="navCalendar">
+      <i class="fa-solid fa-calendar"></i><span data-i18n="navCalendar">Kalender</span>
     </button>
-    <button class="nav-btn" data-route="rain" role="tab" aria-selected="false" aria-label="Niederschlag">
-      <i class="fa-solid fa-cloud-rain"></i><span>Regen</span>
+    <button class="nav-btn" data-route="rain" role="tab" aria-selected="false" data-i18n-aria-label="navRain">
+      <i class="fa-solid fa-cloud-rain"></i><span data-i18n="navRain">Regen</span>
     </button>
   </nav>
 
   <!-- Settings-Dialog (AA/AAA-konform) -->
-  <dialog id="settings" class="modal" aria-modal="true" aria-label="Einstellungen">
+  <dialog id="settings" class="modal" aria-modal="true" data-i18n-aria-label="settings">
     <form method="dialog" class="card">
       <header class="card-head">
-        <h2>Einstellungen</h2>
-        <button class="icon-btn" value="cancel" aria-label="Schließen">
+        <h2 data-i18n="settings">Einstellungen</h2>
+        <button class="icon-btn" value="cancel" data-i18n-aria-label="close">
           <i class="fa-solid fa-xmark"></i>
         </button>
       </header>
 
       <div class="card-body">
         <fieldset class="group">
-          <legend>Darstellung</legend>
+          <legend data-i18n="appearance">Darstellung</legend>
           <label class="row">
             <input type="checkbox" id="darkToggle" />
-            <span>Dark Mode aktivieren</span>
+            <span data-i18n="darkMode">Dark Mode aktivieren</span>
           </label>
           <label class="row">
             <input type="checkbox" id="reduceMotion" />
-            <span>Animationen reduzieren</span>
+            <span data-i18n="reduceMotion">Animationen reduzieren</span>
           </label>
           <label class="row">
             <input type="checkbox" id="highContrast" />
-            <span>Hohen Kontrast (AAA) aktivieren</span>
+            <span data-i18n="highContrast">Hohen Kontrast (AAA) aktivieren</span>
           </label>
         </fieldset>
 
         <fieldset class="group">
-          <legend>Personalisierung</legend>
+          <legend data-i18n="personalization">Personalisierung</legend>
           <div class="row">
-            <input id="firstName" placeholder="Vorname" autocomplete="given-name" aria-label="Vorname" />
-            <input id="lastName" placeholder="Nachname" autocomplete="family-name" aria-label="Nachname" />
+            <input id="firstName" data-i18n-placeholder="firstName" placeholder="Vorname" autocomplete="given-name" aria-label="Vorname" data-i18n-aria-label="firstName" />
+            <input id="lastName" data-i18n-placeholder="lastName" placeholder="Nachname" autocomplete="family-name" aria-label="Nachname" data-i18n-aria-label="lastName" />
           </div>
-          <p class="hint">Dein Name erscheint an mehreren Stellen (z. B. „Guten Morgen, Michael“).</p>
+          <p class="hint" data-i18n="nameHint">Dein Name erscheint an mehreren Stellen (z. B. „Guten Morgen, Michael“).</p>
+          <label class="row">
+            <span data-i18n="language">Sprache</span>
+            <select id="language">
+              <option value="de">Deutsch</option>
+              <option value="en">English</option>
+            </select>
+          </label>
         </fieldset>
 
         <fieldset class="group">
-          <legend>Datenquelle</legend>
-          <p class="hint">Aktuell werden Demodaten verwendet. Später wird hier ThingsBoard verbunden.</p>
+          <legend data-i18n="dataSource">Datenquelle</legend>
+          <p class="hint" data-i18n="dataHint">Aktuell werden Demodaten verwendet. Später wird hier ThingsBoard verbunden.</p>
         </fieldset>
       </div>
 
       <footer class="card-foot">
-        <button class="btn primary" id="saveSettings" value="default">Speichern</button>
+        <button class="btn primary" id="saveSettings" value="default" data-i18n="save">Speichern</button>
       </footer>
     </form>
   </dialog>

--- a/widgets/calendar.js
+++ b/widgets/calendar.js
@@ -2,7 +2,7 @@
   const root = document.getElementById('calendar');
   const calendar = new FullCalendar.Calendar(root, {
     initialView: 'dayGridMonth',
-    locale: 'de',
+    locale: document.documentElement.lang,
     height: 'auto',
     events: demoEvents()
   });
@@ -12,10 +12,10 @@
     const today = new Date();
     const y = today.getFullYear(), m = today.getMonth();
     return [
-      { title: 'Wartung Station Nussdorf', start: new Date(y, m, 3) },
-      { title: 'Sensorwechsel Waidach', start: new Date(y, m, 10) },
-      { title: 'Sturm – erhöhte Böen', start: new Date(y, m, 14), color: '#f43f5e' },
-      { title: 'Softwareupdate', start: new Date(y, m, 21), color: '#22c55e' }
+      { title: t('evtMaintNussdorf'), start: new Date(y, m, 3) },
+      { title: t('evtSensorWaidach'), start: new Date(y, m, 10) },
+      { title: t('evtStorm'), start: new Date(y, m, 14), color: '#f43f5e' },
+      { title: t('evtSoftwareUpdate'), start: new Date(y, m, 21), color: '#22c55e' }
     ];
   }
 })();

--- a/widgets/dashboard.html
+++ b/widgets/dashboard.html
@@ -6,8 +6,8 @@
   <div class="hero widget-card">
     <div class="hero-row">
       <div>
-        <div class="hello" id="helloText">Hallo!</div>
-        <div class="sub">Demodaten – ThingsBoard Anbindung folgt.</div>
+        <div class="hello" id="helloText" data-i18n="hello">Hallo!</div>
+        <div class="sub" data-i18n="demoSub">Demodaten – ThingsBoard Anbindung folgt.</div>
       </div>
       <div class="now">
         <div class="deg" id="nowDeg">--°</div>
@@ -19,11 +19,11 @@
 
 <section class="widget-6">
   <div class="widget-card kpi" id="cardTemp">
-    <header><i class="fa-solid fa-thermometer-half"></i><h3>Temperatur</h3><span id="trendTemp" class="status">—</span></header>
+    <header><i class="fa-solid fa-thermometer-half"></i><h3 data-i18n="temperature">Temperatur</h3><span id="trendTemp" class="status">—</span></header>
     <div class="kpi-grid">
-      <div><div class="label">Aktuell</div><div class="value" id="tempNow">--.- °C</div></div>
-      <div><div class="label">Min heute</div><div class="value" id="tempMin">--.- °C</div></div>
-      <div><div class="label">Max heute</div><div class="value" id="tempMax">--.- °C</div></div>
+      <div><div class="label" data-i18n="current">Aktuell</div><div class="value" id="tempNow">--.- °C</div></div>
+      <div><div class="label" data-i18n="minToday">Min heute</div><div class="value" id="tempMin">--.- °C</div></div>
+      <div><div class="label" data-i18n="maxToday">Max heute</div><div class="value" id="tempMax">--.- °C</div></div>
     </div>
     <div id="sparkTemp" class="spark"></div>
   </div>
@@ -31,11 +31,11 @@
 
 <section class="widget-6">
   <div class="widget-card kpi" id="cardRain">
-    <header><i class="fa-solid fa-cloud-showers-heavy"></i><h3>Niederschlag</h3><span id="rainIntensity" class="status">—</span></header>
+    <header><i class="fa-solid fa-cloud-showers-heavy"></i><h3 data-i18n="rain">Niederschlag</h3><span id="rainIntensity" class="status">—</span></header>
     <div class="kpi-grid">
-      <div><div class="label">Heute</div><div class="value" id="rainToday">--.- mm</div></div>
-      <div><div class="label">Letzte Stunde</div><div class="value" id="rain1h">--.- mm</div></div>
-      <div><div class="label">24 h Summe</div><div class="value" id="rain24h">--.- mm</div></div>
+      <div><div class="label" data-i18n="today">Heute</div><div class="value" id="rainToday">--.- mm</div></div>
+      <div><div class="label" data-i18n="lastHour">Letzte Stunde</div><div class="value" id="rain1h">--.- mm</div></div>
+      <div><div class="label" data-i18n="sum24h">24 h Summe</div><div class="value" id="rain24h">--.- mm</div></div>
     </div>
     <div id="sparkRain" class="spark"></div>
   </div>
@@ -43,11 +43,11 @@
 
 <section class="widget-6">
   <div class="widget-card kpi" id="cardWind">
-    <header><i class="fa-solid fa-wind"></i><h3>Wind</h3><span id="trendWind" class="status">—</span></header>
+    <header><i class="fa-solid fa-wind"></i><h3 data-i18n="wind">Wind</h3><span id="trendWind" class="status">—</span></header>
     <div class="kpi-grid">
-      <div><div class="label">Ø</div><div class="value" id="windAvg">--.- km/h</div></div>
-      <div><div class="label">Böe</div><div class="value" id="windGust">--.- km/h</div></div>
-      <div><div class="label">Richtung</div><div class="value" id="windDir">—</div></div>
+      <div><div class="label" data-i18n="average">Ø</div><div class="value" id="windAvg">--.- km/h</div></div>
+      <div><div class="label" data-i18n="gust">Böe</div><div class="value" id="windGust">--.- km/h</div></div>
+      <div><div class="label" data-i18n="direction">Richtung</div><div class="value" id="windDir">—</div></div>
     </div>
     <div id="sparkWind" class="spark"></div>
   </div>
@@ -55,11 +55,11 @@
 
 <section class="widget-6">
   <div class="widget-card kpi" id="cardHum">
-    <header><i class="fa-solid fa-droplet"></i><h3>Luftfeuchte</h3><span id="trendHum" class="status">—</span></header>
+    <header><i class="fa-solid fa-droplet"></i><h3 data-i18n="humidity">Luftfeuchte</h3><span id="trendHum" class="status">—</span></header>
     <div class="kpi-grid">
-      <div><div class="label">Aktuell</div><div class="value" id="humNow">-- %</div></div>
-      <div><div class="label">Min heute</div><div class="value" id="humMin">-- %</div></div>
-      <div><div class="label">Max heute</div><div class="value" id="humMax">-- %</div></div>
+      <div><div class="label" data-i18n="current">Aktuell</div><div class="value" id="humNow">-- %</div></div>
+      <div><div class="label" data-i18n="minToday">Min heute</div><div class="value" id="humMin">-- %</div></div>
+      <div><div class="label" data-i18n="maxToday">Max heute</div><div class="value" id="humMax">-- %</div></div>
     </div>
     <div id="sparkHum" class="spark"></div>
   </div>

--- a/widgets/dashboard.js
+++ b/widgets/dashboard.js
@@ -12,7 +12,8 @@
   document.addEventListener('cws:user', (e)=>{
     const { firstName } = e.detail || {};
     const hello = document.getElementById('helloText');
-    if (firstName) hello.textContent = `Hallo ${firstName}!`;
+    if (firstName) hello.textContent = t('helloName').replace('{name}', firstName);
+    else hello.textContent = t('hello');
   });
 
   // NOW
@@ -20,8 +21,8 @@
   const hiT  = max(temps);
   const loT  = min(temps);
   document.getElementById('nowDeg').textContent = `${nowT.toFixed(1)}°`;
-  document.getElementById('nowHi').textContent  = `H ${hiT.toFixed(1)}°`;
-  document.getElementById('nowLo').textContent  = `T ${loT.toFixed(1)}°`;
+  document.getElementById('nowHi').textContent  = `${t('highShort')} ${hiT.toFixed(1)}°`;
+  document.getElementById('nowLo').textContent  = `${t('lowShort')} ${loT.toFixed(1)}°`;
 
   // KPIs
   $('#tempNow').textContent = `${nowT.toFixed(1)} °C`;

--- a/widgets/map.html
+++ b/widgets/map.html
@@ -1,7 +1,7 @@
 <link rel="stylesheet" href="widgets/map.css" />
 <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
 <section class="widget-12 widget-host">
-  <div id="leaflet" class="map" role="region" aria-label="Karte"></div>
+  <div id="leaflet" class="map" role="region" data-i18n-aria-label="titleMap"></div>
 </section>
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 <script defer src="widgets/map.js"></script>

--- a/widgets/rain.html
+++ b/widgets/rain.html
@@ -1,13 +1,13 @@
 <link rel="stylesheet" href="widgets/rain.css" />
 <section class="widget-12 widget-card rain">
   <header class="rain-head">
-    <h3><i class="fa-solid fa-cloud-rain"></i> Niederschlags-Übersicht</h3>
+    <h3><i class="fa-solid fa-cloud-rain"></i> <span data-i18n="rainOverview">Niederschlags-Übersicht</span></h3>
     <div class="right">
       <select id="range">
-        <option value="24">24 h</option>
-        <option value="48">48 h</option>
-        <option value="7d">7 Tage</option>
-        <option value="30d">30 Tage</option>
+        <option value="24" data-i18n="range24h">24 h</option>
+        <option value="48" data-i18n="range48h">48 h</option>
+        <option value="7d" data-i18n="range7d">7 Tage</option>
+        <option value="30d" data-i18n="range30d">30 Tage</option>
       </select>
     </div>
   </header>

--- a/widgets/rain.js
+++ b/widgets/rain.js
@@ -18,8 +18,8 @@
       const v = (total * (0.7 + Math.random()*0.6)).toFixed(1);
       const el = document.createElement('div');
       el.className = 'item';
-      el.innerHTML = `<div><strong>${s.name}</strong><div style="color:var(--cws-muted)">im Zeitraum</div></div>
-                      <div class="amount">${v} mm</div>`;
+        el.innerHTML = `<div><strong>${s.name}</strong><div style="color:var(--cws-muted)">${t('inPeriod')}</div></div>
+                        <div class="amount">${v} mm</div>`;
       list.appendChild(el);
     }
   }


### PR DESCRIPTION
## Summary
- add translation framework and English strings
- allow selecting app language in settings
- localize widgets and navigation labels

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c2e55a9ddc83299dfeab273a594694