### PR TITLE
Adjust boot gating flow to re-show splash after access

### DIFF
--- a/app.js
+++ b/app.js
@@ -691,7 +691,11 @@ if ('serviceWorker' in navigator) {
   broadcastPrefs(true);
   applyPersonalization();
 
-  await gateAccess();
+  hideSplash();
+  const accessGranted = await gateAccess();
+  if (!accessGranted) return;
+
+  showSplash(12);
   firstRun();
   await mount('dashboard');
 })();


### PR DESCRIPTION
## Summary
- hide the splash screen before awaiting gate access so the dialog is not obstructed
- restore the splash indicator immediately after access is granted before mounting the dashboard

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ca87e43c9c83299423d97ba937cc10