### PR TITLE
Add metric detail popups for dashboard cards

### DIFF
--- a/app.js
+++ b/app.js
@@ -80,6 +80,20 @@ const translations = {
     rain: 'Niederschlag',
     wind: 'Wind',
     humidity: 'Luftfeuchte',
+    metricDetailsTitle: 'Messwert-Details',
+    metricDetailsAria: 'Details zum Messwert',
+    metricDetailsStation: 'Station',
+    metricDetailsLocation: 'Position',
+    metricDetailsElevation: 'Höhe',
+    metricDetailsUnit: 'Einheit',
+    metricDetailsUpdated: 'Letzte Aktualisierung',
+    metricDetailsTrend: 'Trend',
+    metricDetailsTrendUp: 'steigend',
+    metricDetailsTrendDown: 'fallend',
+    metricDetailsTrendStable: 'stabil',
+    metricDetailsShow: 'Details anzeigen: {metric}',
+    metricDetailsNoData: 'Keine Detaildaten verfügbar.',
+    metricDetailsPeriod24h: 'letzte 24 h',
     current: 'Aktuell',
     minToday: 'Min heute',
     maxToday: 'Max heute',
@@ -209,6 +223,20 @@ const translations = {
     rain: 'Rain',
     wind: 'Wind',
     humidity: 'Humidity',
+    metricDetailsTitle: 'Measurement details',
+    metricDetailsAria: 'Measurement details dialog',
+    metricDetailsStation: 'Station',
+    metricDetailsLocation: 'Location',
+    metricDetailsElevation: 'Elevation',
+    metricDetailsUnit: 'Unit',
+    metricDetailsUpdated: 'Last update',
+    metricDetailsTrend: 'Trend',
+    metricDetailsTrendUp: 'rising',
+    metricDetailsTrendDown: 'falling',
+    metricDetailsTrendStable: 'steady',
+    metricDetailsShow: 'Show details: {metric}',
+    metricDetailsNoData: 'No detailed data available.',
+    metricDetailsPeriod24h: 'last 24 h',
     current: 'Current',
     minToday: 'Min today',
     maxToday: 'Max today',
@@ -281,6 +309,8 @@ const translations = {
     insightsAvgPerDay: 'Avg per day'
   }
 };
+
+window.CWS = window.CWS || {};
 
 const legalTexts = {
   privacy: {
@@ -808,6 +838,118 @@ function firstRun(){
   openSettingsDialog();
   save('cws_seen', true);
 }
+
+/* ---------------- Metric Details Dialog ---------------- */
+const metricDialog = $('#metricDialog');
+const metricDialogTitle = $('#metricDialogTitle');
+const metricDialogSubtitle = $('#metricDialogSubtitle');
+const metricDialogList = $('#metricDialogList');
+const metricDialogMeta = $('#metricDialogMeta');
+const metricDialogNote = $('#metricDialogNote');
+const metricDialogEmpty = $('#metricDialogEmpty');
+
+function resetMetricDialog(){
+  if (metricDialogList) {
+    metricDialogList.innerHTML = '';
+    metricDialogList.hidden = true;
+  }
+  if (metricDialogMeta) {
+    metricDialogMeta.innerHTML = '';
+    metricDialogMeta.hidden = true;
+  }
+  if (metricDialogNote) {
+    metricDialogNote.textContent = '';
+    metricDialogNote.hidden = true;
+  }
+  if (metricDialogEmpty) {
+    metricDialogEmpty.hidden = true;
+  }
+}
+
+function fillMetricItems(container, items){
+  if (!container) return false;
+  container.innerHTML = '';
+  if (!Array.isArray(items) || !items.length) {
+    container.hidden = true;
+    return false;
+  }
+  container.hidden = false;
+  items.forEach(item => {
+    const block = document.createElement('div');
+    block.className = 'metric-item';
+    const label = document.createElement('div');
+    label.className = 'metric-item-label';
+    label.textContent = item?.label ?? '';
+    const value = document.createElement('div');
+    value.className = 'metric-item-value';
+    value.textContent = item?.value ?? '';
+    block.append(label, value);
+    if (item?.hint) {
+      const hint = document.createElement('div');
+      hint.className = 'metric-item-hint';
+      hint.textContent = item.hint;
+      block.appendChild(hint);
+    }
+    container.appendChild(block);
+  });
+  return true;
+}
+
+function fillMetricMeta(container, meta){
+  if (!container) return false;
+  container.innerHTML = '';
+  if (!Array.isArray(meta) || !meta.length) {
+    container.hidden = true;
+    return false;
+  }
+  container.hidden = false;
+  meta.forEach(item => {
+    const row = document.createElement('div');
+    row.className = 'metric-meta-row';
+    const label = document.createElement('span');
+    label.className = 'metric-meta-label';
+    label.textContent = item?.label ?? '';
+    const value = document.createElement('span');
+    value.className = 'metric-meta-value';
+    value.textContent = item?.value ?? '';
+    row.append(label, value);
+    container.appendChild(row);
+  });
+  return true;
+}
+
+function showMetricDetails(detail={}){
+  if (!metricDialog) return;
+  resetMetricDialog();
+  const title = detail.title || t('metricDetailsTitle');
+  if (metricDialogTitle) metricDialogTitle.textContent = title;
+  if (metricDialogSubtitle) {
+    const subtitle = (detail.subtitle || '').toString().trim();
+    metricDialogSubtitle.textContent = subtitle;
+    metricDialogSubtitle.hidden = subtitle.length === 0;
+  }
+  const hasItems = fillMetricItems(metricDialogList, detail.items);
+  const hasMeta = fillMetricMeta(metricDialogMeta, detail.meta);
+  if (metricDialogNote) {
+    const note = (detail.note || '').toString().trim();
+    metricDialogNote.textContent = note;
+    metricDialogNote.hidden = note.length === 0;
+  }
+  if (metricDialogEmpty) {
+    const showEmpty = !(hasItems || hasMeta || ((detail.note || '').toString().trim().length > 0));
+    metricDialogEmpty.hidden = !showEmpty;
+    if (showEmpty) {
+      metricDialogEmpty.textContent = t('metricDetailsNoData');
+    }
+  }
+  metricDialog.showModal();
+}
+
+if (metricDialog) {
+  metricDialog.addEventListener('close', resetMetricDialog);
+}
+
+window.CWS.showMetricDetails = showMetricDetails;
 
 /* ---------------- Legal Buttons ---------------- */
 $$('.footer-btn[data-legal]').forEach(btn => {

--- a/index.html
+++ b/index.html
@@ -188,6 +188,27 @@
     </form>
   </dialog>
 
+  <dialog id="metricDialog" class="modal metric-modal" aria-modal="true" data-i18n-aria-label="metricDetailsAria">
+    <form method="dialog" class="card">
+      <header class="card-head">
+        <h2 id="metricDialogTitle" data-i18n="metricDetailsTitle">Messwert-Details</h2>
+        <button class="icon-btn" value="cancel" data-i18n-aria-label="close">
+          <i class="fa-solid fa-xmark"></i>
+        </button>
+      </header>
+      <div class="card-body metric-body">
+        <p class="metric-subtitle" id="metricDialogSubtitle" hidden></p>
+        <div class="metric-grid" id="metricDialogList"></div>
+        <div class="metric-meta" id="metricDialogMeta"></div>
+        <p class="metric-note" id="metricDialogNote" hidden></p>
+        <p class="metric-empty" id="metricDialogEmpty" hidden data-i18n="metricDetailsNoData">Keine Detaildaten verfügbar.</p>
+      </div>
+      <footer class="card-foot metric-foot">
+        <button class="btn primary" value="default" data-i18n="close">Schließen</button>
+      </footer>
+    </form>
+  </dialog>
+
   <dialog id="accessGate" class="modal gate-modal" aria-modal="true" data-i18n-aria-label="accessTitle">
     <form method="dialog" class="card">
       <header class="card-head">

--- a/styles.css
+++ b/styles.css
@@ -383,6 +383,15 @@ body {
   box-shadow: 0 12px 22px -18px rgba(16, 44, 65, 0.28);
 }
 
+.metric-card {
+  cursor: pointer;
+}
+
+.metric-card:focus-visible {
+  outline: 3px solid var(--cws-accent);
+  outline-offset: 4px;
+}
+
 .card-head,
 .card-foot {
   padding: 16px 20px;
@@ -515,6 +524,96 @@ select:focus-visible {
 .legal-modal .card,
 .gate-modal .card {
   width: min(640px, 92vw);
+}
+
+.metric-modal .card {
+  width: min(640px, 92vw);
+}
+
+.metric-body {
+  gap: 20px;
+}
+
+.metric-subtitle {
+  margin: 0;
+  font-weight: 600;
+  color: var(--cws-primary-strong);
+}
+
+.metric-grid {
+  display: grid;
+  gap: 14px;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.metric-item {
+  padding: 14px;
+  border: 1px solid color-mix(in srgb, var(--cws-border) 70%, transparent);
+  border-radius: var(--radius);
+  background: color-mix(in srgb, var(--cws-surface) 92%, transparent);
+  display: grid;
+  gap: 6px;
+}
+
+.metric-item-label {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: color-mix(in srgb, var(--cws-text) 70%, var(--cws-muted));
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+}
+
+.metric-item-value {
+  font-size: 1.18rem;
+  font-weight: 700;
+  color: var(--cws-text);
+  font-variant-numeric: tabular-nums;
+}
+
+.metric-item-hint {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--cws-muted);
+}
+
+.metric-meta {
+  display: grid;
+  gap: 10px;
+}
+
+.metric-meta-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: baseline;
+}
+
+.metric-meta-label {
+  font-weight: 600;
+  color: color-mix(in srgb, var(--cws-text) 80%, var(--cws-muted));
+}
+
+.metric-meta-value {
+  margin-left: auto;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.metric-note {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--cws-muted);
+}
+
+.metric-empty {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--cws-muted);
+  font-style: italic;
+}
+
+.metric-foot {
+  justify-content: flex-end;
 }
 
 .legal-body {

--- a/widgets/dashboard.html
+++ b/widgets/dashboard.html
@@ -18,7 +18,7 @@
 </section>
 
 <section class="widget-6">
-  <div class="widget-card kpi" id="cardTemp">
+  <div class="widget-card kpi metric-card" id="cardTemp" data-metric="temperature">
     <header><i class="fa-solid fa-thermometer-half"></i><h3 data-i18n="temperature">Temperatur</h3><span id="trendTemp" class="status">—</span></header>
     <div class="kpi-grid">
       <div><div class="label" data-i18n="current">Aktuell</div><div class="value" id="tempNow">--</div></div>
@@ -30,7 +30,7 @@
 </section>
 
 <section class="widget-6">
-  <div class="widget-card kpi" id="cardRain">
+  <div class="widget-card kpi metric-card" id="cardRain" data-metric="rain">
     <header><i class="fa-solid fa-cloud-showers-heavy"></i><h3 data-i18n="rain">Niederschlag</h3><span id="rainIntensity" class="status">—</span></header>
     <div class="kpi-grid">
       <div><div class="label" data-i18n="today">Heute</div><div class="value" id="rainToday">--</div></div>
@@ -42,7 +42,7 @@
 </section>
 
 <section class="widget-6">
-  <div class="widget-card kpi" id="cardWind">
+  <div class="widget-card kpi metric-card" id="cardWind" data-metric="wind">
     <header><i class="fa-solid fa-wind"></i><h3 data-i18n="wind">Wind</h3><span id="trendWind" class="status">—</span></header>
     <div class="kpi-grid">
       <div><div class="label" data-i18n="average">Ø</div><div class="value" id="windAvg">--</div></div>
@@ -54,7 +54,7 @@
 </section>
 
 <section class="widget-6">
-  <div class="widget-card kpi" id="cardHum">
+  <div class="widget-card kpi metric-card" id="cardHum" data-metric="humidity">
     <header><i class="fa-solid fa-droplet"></i><h3 data-i18n="humidity">Luftfeuchte</h3><span id="trendHum" class="status">—</span></header>
     <div class="kpi-grid">
       <div><div class="label" data-i18n="current">Aktuell</div><div class="value" id="humNow">--</div></div>

--- a/widgets/dashboard.js
+++ b/widgets/dashboard.js
@@ -4,6 +4,8 @@
   let units = (window.CWS_PREFS && window.CWS_PREFS.units) || 'metric';
   let favorite = (window.CWS_PREFS && window.CWS_PREFS.favoriteStation) || '';
   const charts = {};
+  const metricDetails = {};
+  const metricCards = new Map();
   if (!series.length) return;
 
   const sum = arr => arr.reduce((s, v) => s + v, 0);
@@ -21,6 +23,96 @@
     if (favorite && perStation[favorite]) return perStation[favorite];
     const firstKey = Object.keys(perStation)[0];
     return firstKey ? perStation[firstKey] : null;
+  }
+
+  function formatTimestamp(value){
+    if (!value) return '—';
+    try {
+      return new Intl.DateTimeFormat(document.documentElement.lang || undefined, {
+        dateStyle: 'medium',
+        timeStyle: 'short'
+      }).format(new Date(value));
+    } catch {
+      try {
+        return new Date(value).toLocaleString();
+      } catch {
+        return '—';
+      }
+    }
+  }
+
+  function formatCoord(value, positive, negative){
+    if (!Number.isFinite(value)) return '—';
+    const suffix = value >= 0 ? positive : negative;
+    return `${Math.abs(value).toFixed(4)}°${suffix}`;
+  }
+
+  function buildStationMeta(station){
+    if (!station?.info) return [];
+    const meta = [];
+    const info = station.info;
+    if (info.name) meta.push({ label: t('metricDetailsStation'), value: info.name });
+    if (Number.isFinite(info.lat) && Number.isFinite(info.lon)) {
+      meta.push({
+        label: t('metricDetailsLocation'),
+        value: `${formatCoord(info.lat, 'N', 'S')}, ${formatCoord(info.lon, 'E', 'W')}`
+      });
+    }
+    if (Number.isFinite(info.elevation)) {
+      meta.push({ label: t('metricDetailsElevation'), value: `${Math.round(info.elevation)} m` });
+    }
+    return meta;
+  }
+
+  function describeTrend(symbol){
+    switch (symbol) {
+      case '↑': return t('metricDetailsTrendUp');
+      case '↓': return t('metricDetailsTrendDown');
+      case '→': return t('metricDetailsTrendStable');
+      default: return '';
+    }
+  }
+
+  function trendText(symbol){
+    const word = describeTrend(symbol);
+    return word ? `${symbol} ${word}` : symbol;
+  }
+
+  function openMetricDetails(key){
+    const detail = metricDetails[key];
+    const show = window.CWS?.showMetricDetails;
+    if (detail && typeof show === 'function') {
+      show(detail);
+    }
+  }
+
+  function registerCard(id, key){
+    const card = document.getElementById(id);
+    if (!card || metricCards.has(key)) return;
+    metricCards.set(key, card);
+    card.setAttribute('role', 'button');
+    card.setAttribute('tabindex', '0');
+    card.classList.add('metric-card');
+    card.addEventListener('click', () => openMetricDetails(key));
+    card.addEventListener('keydown', ev => {
+      if (ev.key === 'Enter' || ev.key === ' ' || ev.key === 'Spacebar') {
+        ev.preventDefault();
+        openMetricDetails(key);
+      }
+    });
+  }
+
+  function updateCardLabels(){
+    metricCards.forEach((card, key) => {
+      if (!card) return;
+      const detail = metricDetails[key];
+      if (detail?.title) {
+        const label = t('metricDetailsShow').replace('{metric}', detail.title);
+        card.setAttribute('aria-label', label);
+      } else {
+        card.removeAttribute('aria-label');
+      }
+    });
   }
 
   function trendSymbol(values){
@@ -47,6 +139,7 @@
     const nowTemp = temps[temps.length - 1] || 0;
     const hiTemp = Math.max(...temps);
     const loTemp = Math.min(...temps);
+    const tempTrend = trendSymbol(temps);
 
     $('#nowDeg').textContent = `${nowTemp.toFixed(1)}${tempUnit()}`;
     $('#nowHi').textContent = `${t('highShort')} ${hiTemp.toFixed(1)}${tempUnit()}`;
@@ -55,32 +148,118 @@
     $('#tempNow').textContent = `${nowTemp.toFixed(1)} ${tempUnit()}`;
     $('#tempMin').textContent = `${loTemp.toFixed(1)} ${tempUnit()}`;
     $('#tempMax').textContent = `${hiTemp.toFixed(1)} ${tempUnit()}`;
-    $('#trendTemp').textContent = trendSymbol(temps);
+    $('#trendTemp').textContent = tempTrend;
 
     const rainToday = sum(rains);
     const rain1h = sum(rains.slice(-2));
     const rain24 = sum(rains.slice(-48));
+    const rainTrend = trendSymbol(rains);
     $('#rainToday').textContent = formatRain(rainToday);
     $('#rain1h').textContent = formatRain(rain1h);
     $('#rain24h').textContent = formatRain(rain24);
-    $('#rainIntensity').textContent = trendSymbol(rains);
+    $('#rainIntensity').textContent = rainTrend;
 
     const windAverage = avg(winds);
     const station = currentStation();
     const stationCurrent = station?.current;
-    const gust = stationCurrent ? convertWind(stationCurrent.windGust) : Math.max(...winds) + 2.4;
+    const fallbackGustBase = winds.length ? Math.max(...winds) : windAverage;
+    const gust = stationCurrent ? convertWind(stationCurrent.windGust) : fallbackGustBase + 2.4;
     const direction = stationCurrent?.windDirection || '—';
+    const windTrend = trendSymbol(winds);
 
     $('#windAvg').textContent = `${windAverage.toFixed(1)} ${windUnit()}`;
     $('#windGust').textContent = `${gust.toFixed(1)} ${windUnit()}`;
     $('#windDir').textContent = direction;
-    $('#trendWind').textContent = trendSymbol(winds);
+    $('#trendWind').textContent = windTrend;
 
     const humNow = hums[hums.length - 1] || 0;
+    const humMin = Math.min(...hums);
+    const humMax = Math.max(...hums);
+    const humTrend = trendSymbol(hums);
     $('#humNow').textContent = `${humNow.toFixed(0)} %`;
-    $('#humMin').textContent = `${Math.min(...hums).toFixed(0)} %`;
-    $('#humMax').textContent = `${Math.max(...hums).toFixed(0)} %`;
-    $('#trendHum').textContent = trendSymbol(hums);
+    $('#humMin').textContent = `${humMin.toFixed(0)} %`;
+    $('#humMax').textContent = `${humMax.toFixed(0)} %`;
+    $('#trendHum').textContent = humTrend;
+
+    const stationSubtitle = station?.info?.name || '';
+    const stationMeta = buildStationMeta(station);
+    const lastPoint = series[series.length - 1] || {};
+    const lastUpdateTs = stationCurrent?.lastUpdate || lastPoint.t || Date.now();
+    const updatedAt = formatTimestamp(lastUpdateTs);
+    const tempAvg = avg(temps);
+    const rainAvg = avg(rains);
+    const humAvg = avg(hums);
+    const windMax = winds.length ? Math.max(...winds) : windAverage;
+
+    metricDetails.temperature = {
+      title: t('temperature'),
+      subtitle: stationSubtitle,
+      items: [
+        { label: t('current'), value: `${nowTemp.toFixed(1)} ${tempUnit()}` },
+        { label: t('minToday'), value: `${loTemp.toFixed(1)} ${tempUnit()}` },
+        { label: t('maxToday'), value: `${hiTemp.toFixed(1)} ${tempUnit()}` },
+        { label: `${t('average')} · ${t('range24h')}`, value: `${tempAvg.toFixed(1)} ${tempUnit()}`, hint: t('metricDetailsPeriod24h') }
+      ],
+      meta: [
+        ...stationMeta,
+        { label: t('metricDetailsTrend'), value: trendText(tempTrend) },
+        { label: t('metricDetailsUnit'), value: tempUnit() },
+        { label: t('metricDetailsUpdated'), value: updatedAt }
+      ]
+    };
+
+    metricDetails.rain = {
+      title: t('rain'),
+      subtitle: stationSubtitle,
+      items: [
+        { label: t('today'), value: formatRain(rainToday) },
+        { label: t('lastHour'), value: formatRain(rain1h) },
+        { label: t('sum24h'), value: formatRain(rain24) },
+        { label: `${t('average')} · ${t('range24h')}`, value: formatRain(rainAvg), hint: t('metricDetailsPeriod24h') }
+      ],
+      meta: [
+        ...stationMeta,
+        { label: t('metricDetailsTrend'), value: trendText(rainTrend) },
+        { label: t('metricDetailsUnit'), value: rainUnit() },
+        { label: t('metricDetailsUpdated'), value: updatedAt }
+      ]
+    };
+
+    metricDetails.wind = {
+      title: t('wind'),
+      subtitle: stationSubtitle,
+      items: [
+        { label: `${t('average')} · ${t('range24h')}`, value: `${windAverage.toFixed(1)} ${windUnit()}`, hint: t('metricDetailsPeriod24h') },
+        { label: t('gust'), value: `${gust.toFixed(1)} ${windUnit()}` },
+        { label: t('statMax'), value: `${windMax.toFixed(1)} ${windUnit()}` },
+        { label: t('direction'), value: direction }
+      ],
+      meta: [
+        ...stationMeta,
+        { label: t('metricDetailsTrend'), value: trendText(windTrend) },
+        { label: t('metricDetailsUnit'), value: windUnit() },
+        { label: t('metricDetailsUpdated'), value: updatedAt }
+      ]
+    };
+
+    metricDetails.humidity = {
+      title: t('humidity'),
+      subtitle: stationSubtitle,
+      items: [
+        { label: t('current'), value: `${humNow.toFixed(0)} %` },
+        { label: t('minToday'), value: `${humMin.toFixed(0)} %` },
+        { label: t('maxToday'), value: `${humMax.toFixed(0)} %` },
+        { label: `${t('average')} · ${t('range24h')}`, value: `${humAvg.toFixed(0)} %`, hint: t('metricDetailsPeriod24h') }
+      ],
+      meta: [
+        ...stationMeta,
+        { label: t('metricDetailsTrend'), value: trendText(humTrend) },
+        { label: t('metricDetailsUnit'), value: '%' },
+        { label: t('metricDetailsUpdated'), value: updatedAt }
+      ]
+    };
+
+    updateCardLabels();
 
     makeSpark('sparkTemp', temps, '#e11d48');
     makeSpark('sparkRain', rains, '#80c0ed');
@@ -128,6 +307,11 @@
     if (!hello) return;
     hello.textContent = firstName ? t('helloName').replace('{name}', firstName) : t('hello');
   });
+
+  registerCard('cardTemp', 'temperature');
+  registerCard('cardRain', 'rain');
+  registerCard('cardWind', 'wind');
+  registerCard('cardHum', 'humidity');
 
   render();
 


### PR DESCRIPTION
## Summary
- add a reusable metric details dialog and wire it to dashboard KPI cards
- compute contextual information (averages, trend, station metadata) for every metric
- style the popup content and enable keyboard/pointer access for the interactive cards

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ca9b6cbdfc832989955db6569d1513